### PR TITLE
Updated Gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip


### PR DESCRIPTION
I noticed that the version of Gradle listed is rather old, and updated the download URL to that of version 4.3.1 in ```gradle/wrapper/gradle-wrapper.properties```.